### PR TITLE
[ENTRY]: migration - model  - OT102-40

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,12 +4,14 @@ module.exports = {
     commonjs: true,
     es2021: true,
   },
-  extends: [
-    'airbnb-base',
-  ],
+  extends: ['airbnb-base'],
   parserOptions: {
     ecmaVersion: 12,
   },
   rules: {
+    'linebreak-style': [
+      'error',
+      process.platform === 'win32' ? 'windows' : 'unix',
+    ],
   },
 };

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 package-lock.json
 yarn.lock
 request.http
+.vscode/

--- a/migrations/20211123135111-create-entry.js
+++ b/migrations/20211123135111-create-entry.js
@@ -1,0 +1,51 @@
+'use strict';
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('Entries', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      name: {
+        allowNull: false,
+        type: Sequelize.STRING,
+      },
+      content: {
+        allowNull: false,
+        type: Sequelize.TEXT,
+      },
+      image: {
+        type: Sequelize.STRING,
+      },
+      categoryId: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'Categories',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      type: {
+        allowNull: false,
+        type: Sequelize.STRING,
+      },
+      deletedAt: {
+        type: Sequelize.DATE,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('Entries');
+  },
+};

--- a/models/entry.js
+++ b/models/entry.js
@@ -8,7 +8,7 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      User.belongsTo(models.Categoy, { as: 'category' });
+      Entry.belongsTo(models.Category, { as: 'category' });
     }
   }
   Entry.init(

--- a/models/entry.js
+++ b/models/entry.js
@@ -23,6 +23,11 @@ module.exports = (sequelize, DataTypes) => {
     {
       sequelize,
       modelName: 'Entry',
+      createdAt: 'created_at',
+      updatedAt: 'updated_at',
+      deletedAt: 'deletedAt',
+      paranoid: true,
+      timestamps: true,
     }
   );
   return Entry;

--- a/models/entry.js
+++ b/models/entry.js
@@ -1,0 +1,29 @@
+'use strict';
+const { Model } = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class Entry extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      User.belongsTo(models.Categoy, { as: 'category' });
+    }
+  }
+  Entry.init(
+    {
+      name: DataTypes.STRING,
+      content: DataTypes.TEXT,
+      image: DataTypes.STRING,
+      categoryId: DataTypes.INTEGER,
+      type: DataTypes.STRING,
+      deletedAt: DataTypes.DATE,
+    },
+    {
+      sequelize,
+      modelName: 'Entry',
+    }
+  );
+  return Entry;
+};


### PR DESCRIPTION
# Description:
***
AS: administrator user
I WANT: to manage "Novedades" (News)
TO:  manage the content.
 
## Acceptance Criteria:
***
Entries will be the content published under the "Novedades"(News) section of the website. Table name: entries. Fields : name, content, image, categoryId, type (one entry may be an event, news, etc), deletedAt (used for softDelete).

***
## How to reproduce this change:
Create Model:
`sequelize model:generate --name Entry --attributes name:string,content:text,image:string,categoryId:integer,type:string,deletedAt:date`
Apply migration:
`npx sequelize-cli db:migrate`

Undo migration:
`npx sequelize-cli db:migrate:undo:all --to XXXXXXXXXXXXXX-nombre-migracion.js`
***
## Evidence:

![OT102-40](https://user-images.githubusercontent.com/74208929/143047072-f4975df6-ac15-4fd6-ad6c-b48cd4df791b.png)


