### PR TITLE
[ENDPOINT] DELETE /categories/:id - OT102-99

### DIFF
--- a/controllers/categories.js
+++ b/controllers/categories.js
@@ -1,4 +1,7 @@
-const { getAll } = require('../services/categories')
+const { catchAsync } = require('../helpers')
+const { ErrorObject } = require('../helpers/error')
+const { endpointResponse } = require('../helpers/success')
+const { getAll, deleteCategory } = require('../services/categories')
 
 module.exports = {
   get: async (req, res, next) => {
@@ -14,4 +17,21 @@ module.exports = {
       next(error)
     }
   },
+  destroy: catchAsync(async (req, res, next) => {
+    try {
+      const deletedCategory = await deleteCategory(req.params.id)
+      endpointResponse({
+        res,
+        msg: 'Category was succesfully deleted',
+        body: deletedCategory,
+      })
+    } catch (error) {
+      next(
+        new ErrorObject(
+          `[Error deleting Category] - [category - delete]: ${error.message}`,
+          404,
+        ),
+      )
+    }
+  }),
 }

--- a/controllers/categories.js
+++ b/controllers/categories.js
@@ -29,7 +29,7 @@ module.exports = {
       next(
         new ErrorObject(
           `[Error deleting Category] - [category - delete]: ${error.message}`,
-          404,
+          500,
         ),
       )
     }

--- a/routes/categories.js
+++ b/routes/categories.js
@@ -1,8 +1,11 @@
 const express = require('express')
-const { get } = require('../controllers/categories')
+const { get, destroy } = require('../controllers/categories')
 
 const router = new express.Router()
 
+// Get Categories listing:
 router.get('/', get)
+// Delete Category by ID:
+router.delete('/:id', destroy)
 
 module.exports = router

--- a/services/categories.js
+++ b/services/categories.js
@@ -8,7 +8,26 @@ exports.getAll = async () => {
       },
     })
     return categories
-  } catch (e) {
+  } catch (error) {
     throw Error('Error while retrieving categories')
+  }
+}
+
+exports.deleteCategory = async (id) => {
+  try {
+    // Check if category exists per ticket requirement:
+    const categoryById = await Category.findOne({
+      where: { id },
+    })
+    if (!categoryById) {
+      // If category does not exist throw an error.
+      throw Error('No category was found with that ID')
+    } else {
+      // If category exists then delete it.
+      const deleteCategory = await Category.destroy({ where: { id } })
+      return deleteCategory
+    }
+  } catch (error) {
+    throw Error(error.message)
   }
 }


### PR DESCRIPTION
# Description:

AS: User Administrator
I WANT: To delete an existing category
TO: Be able to keep information up to date.

## Acceptance Criteria:

Request to DELETE /categories/:id - Should validate that said category exists and delete it, otherwise it should return an error.

## Evidence:

### DB previous to deletion:
![OT102-99-Pre-delete](https://user-images.githubusercontent.com/74208929/143610608-54254699-2117-469a-844f-f01c0e51c519.png)
***
### Request to route with inexistent ID:
![OT102-99-No Category was found](https://user-images.githubusercontent.com/74208929/143610750-07f3b214-e8fd-40cf-bfb1-8d1ae9d682ba.png)
***
### Request to route with valid ID:
![OT102-99-Success](https://user-images.githubusercontent.com/74208929/143610881-c12c3859-92e2-4b70-bad9-844d5d526678.png)
***
### Resulting DB, deletedAt field generated:
![OT102-99-Success-DB](https://user-images.githubusercontent.com/74208929/143610954-53b54fca-d5e5-42dd-a2f2-e2fb93a6e470.png)

